### PR TITLE
Added main property in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "ngColorThief",
   "version": "0.1.0",
+  "main": "./angular-colorthief.js",
   "authors": [
     "Ian Murray <me@ianmurray.me>"
   ],


### PR DESCRIPTION
Added this to adhere to [Bower](http://bower.io/docs/creating-packages/) standard. Discovered this when trying to include this with [Wiredep](https://github.com/taptapship/wiredep#what-can-go-wrong).
